### PR TITLE
use geo-extent for adjustment of inner tile extent

### DIFF
--- a/src/georaster-layer-for-leaflet.ts
+++ b/src/georaster-layer-for-leaflet.ts
@@ -389,17 +389,17 @@ const GeoRasterLayer: (new (options: GeoRasterLayerOptions) => any) & typeof L.C
       // (unless the projection is purely scaling and translation),
       // so instead just extend the old map bounding box proportionately. 
       {
-        const oldrb = oldExtentOfInnerTileInRasterCRS.bbox;
-        const newrb = extentOfInnerTileInRasterCRS.bbox;
-        const oldmb = extentOfInnerTileInMapCRS.bbox;
-        if ( oldrb[0] != oldrb[2] && oldrb[1] != oldrb[3] ) {
-          let n0 = ((newrb[0]-oldrb[0])/(oldrb[0]-oldrb[2]))*(oldmb[0]-oldmb[2]);
-          let n1 = ((newrb[1]-oldrb[1])/(oldrb[1]-oldrb[3]))*(oldmb[1]-oldmb[3]);
-          let n2 = ((newrb[2]-oldrb[2])/(oldrb[0]-oldrb[2]))*(oldmb[0]-oldmb[2]);
-          let n3 = ((newrb[3]-oldrb[3])/(oldrb[1]-oldrb[3]))*(oldmb[1]-oldmb[3]);
+        const oldrb = new GeoExtent(oldExtentOfInnerTileInRasterCRS.bbox);
+        const newrb = new GeoExtent(extentOfInnerTileInRasterCRS.bbox);
+        const oldmb = new GeoExtent(extentOfInnerTileInMapCRS.bbox);
+        if (oldrb.width !== 0 && oldrb.height !== 0) {
+          let n0 = ((newrb.xmin - oldrb.xmin) / oldrb.width) * oldmb.width;
+          let n1 = ((newrb.ymin - oldrb.ymin) / oldrb.height) * oldmb.height;
+          let n2 = ((newrb.xmax - oldrb.xmax) / oldrb.width) * oldmb.width;
+          let n3 = ((newrb.ymax - oldrb.ymax) / oldrb.height) * oldmb.height;
           if ( ! overdrawTileAcross ) { n0 = Math.max(n0,0); n2 = Math.min(n2,0); }
           if ( ! overdrawTileDown   ) { n1 = Math.max(n1,0); n3 = Math.min(n3,0); }
-          const newbox = [ oldmb[0] + n0, oldmb[1] + n1, oldmb[2] + n2, oldmb[3] + n3 ];
+          const newbox = [oldmb.xmin + n0, oldmb.ymin + n1, oldmb.xmax + n2, oldmb.ymax + n3];
           extentOfInnerTileInMapCRS = new GeoExtent(newbox, { srs: extentOfInnerTileInMapCRS.srs });
         }
       }


### PR DESCRIPTION
Hi, @jcphill .  Sorry it's taken me so long to get back to you.  I can tell the PR was a lot of work and I'm committed to getting it merged in.   I, too, am in favor of displaying the most accurate representation of the data even if the pixel boundaries aren't smooth in high zoom levels because of differences in projection systems.  I've submitted this PR for a small suggestion to use geo-extent in another part of the code.  It's my hope that this will make the code a little more accessible for other people while having a negligible impact on performance. 

Thanks and let me know if you have any questions :-)